### PR TITLE
修复了文档内一个bug

### DIFF
--- a/docs/第十一章：美化.md
+++ b/docs/第十一章：美化.md
@@ -38,7 +38,7 @@
 
 Flask-Bootstrap需要像大多数其他Flask插件一样被初始化：
 
-*app/__init__.py*: Flask-Bootstrap实例。
+*app/\_\_init\_\_.py*: Flask-Bootstrap实例。
 ```
 # ...
 from flask_bootstrap import Bootstrap


### PR DESCRIPTION
第十一章美化文档，\_\_init\_\_.py 的下划线没有转义导致显示错误，对其进行修正