### PR TITLE
Update 第十三章：国际化和本地化.md

### DIFF
--- a/docs/第十三章：国际化和本地化.md
+++ b/docs/第十三章：国际化和本地化.md
@@ -277,7 +277,7 @@ def get_locale():
 如果在添加`_()`包装器时错过了一些文本，则会出现另一种常见情况。 在这种情况下，你会发现你错过的那些文本将保持为英文，因为Flask-Babel对他们一无所知。 当你检测到这种情况时，会想要将其用`_()`或`_l()`包装，然后执行更新过程，这包括两个步骤：
 
 ```
-(venv) $ pybabel extract -f babel.cfg -k _l -o messages.pot .
+(venv) $ pybabel extract -F babel.cfg -k _l -o messages.pot .
 (venv) $ pybabel update -i messages.pot -d app/translations
 ```
 


### PR DESCRIPTION
提取文本的命令参数有问题。改为
(venv) $ pybabel extract -F babel.cfg -k _l -o messages.pot .