### PR TITLE
下划线未转义

### DIFF
--- a/docs/第七章：错误处理.md
+++ b/docs/第七章：错误处理.md
@@ -111,7 +111,7 @@ def internal_error(error):
 这两个模板都从`base.html`基础模板继承而来，所以错误页面与应用的普通页面有相同的外观布局。
 
 为了让这些错误处理程序在Flask中注册，我需要在应用实例创建后导入新的*app/errors.py*模块。
-app/__init__.py：
+app/\_\_init\_\_.py：
 ```
 # ...
 

--- a/docs/第七章：错误处理.md
+++ b/docs/第七章：错误处理.md
@@ -198,7 +198,7 @@ Gmail帐户中的安全功能可能会阻止应用通过它发送电子邮件，
 通过电子邮件来接收错误提示非常棒，但在其他场景下，有时候就有些不足了。有些错误条件既不是一个Python异常又不是重大事故，但是他们在调试的时候也是有足够用处的。为此，我将会为本应用维持一个日志文件。
 
 为了启用另一个基于文件类型[RotatingFileHandler](https://docs.python.org/3.6/library/logging.handlers.html#rotatingfilehandler)的日志记录器，需要以和电子邮件日志记录器类似的方式将其附加到应用的logger对象中。
-app/__init__.py：
+app/\_\_init\_\_.py：
 ```
 # ...
 from logging.handlers import RotatingFileHandler


### PR DESCRIPTION
文章中的__init__.py，下划线未转义，被GitHub解释成加粗的语法