### PR TITLE
Update 第十五章：优化应用结构.md

### DIFF
--- a/docs/第十五章：优化应用结构.md
+++ b/docs/第十五章：优化应用结构.md
@@ -12,7 +12,7 @@ Microblog已经是一个初具规模的应用了，所以我认为这是讨论Fl
 
 目前状态下的应用有两个基本问题。 如果你观察应用的组织方式，你会注意到有几个不同的子系统可以被识别，但支持它们的代码都混合在了一起，没有任何明确的界限。 我们来回顾一下这些子系统是什么：
 
-*  用户认证子系统，包括*app/routes.py*中的一些视图函数，*app/forms.py*中的一些表单，*app/templates*中的一些模板以及*app/email.py中的电子邮件支持。
+*  用户认证子系统，包括*app/routes.py*中的一些视图函数，*app/forms.py*中的一些表单，*app/templates*中的一些模板以及*app/email.py*中的电子邮件支持。
 *  错误子系统，它在*app/errors.py*中定义了错误处理程序并在*app/templates*中定义了模板。
 *  核心应用功能，包括显示和撰写用户动态，用户个人主页和关注以及用户动态的实时翻译，这些功能遍布大多数应用模块和模板。
 
@@ -124,7 +124,7 @@ app.register_blueprint(auth_bp, url_prefix='/auth')
 # ...
 ```
 
-在这种情况下，`register_blueprint()`调用接收了一个额外的参数，`url_prefix`。 这完全是可选的，Flask提供了给blueprint的路由添加URL前缀的选项，因此blueprint中定义的任何路由都会在其完整URL中获取此前缀。 在许多情况下，这可以用来当成“命名空间”，它可以将blueprint中的所有路由与应用或其他blueprint中的其他路由分开。 对于用户认证，我认为让所有路由以*/auth*开头很不错，所以我添加了该前缀。 所以现在登录URL将会是*http://localhost:5000/auth/login*。 因为我使用`url_for()`来生成URL，所有URL都会自动合并前缀。
+在这种情况下，`register_blueprint()`调用接收了一个额外的参数，`url_prefix`。 这完全是可选的，Flask提供了给blueprint的路由添加URL前缀的选项，因此blueprint中定义的任何路由都会在其完整URL中获取此前缀。 在许多情况下，这可以用来当成“命名空间”，它可以将blueprint中的所有路由与应用或其他blueprint中的其他路由分开。 对于用户认证，我认为让所有路由以 */auth* 开头很不错，所以我添加了该前缀。 所以现在登录URL将会是  *http://localhost:5000/auth/login* 。 因为我使用`url_for()`来生成URL，所有URL都会自动合并前缀。
 
 ### 主应用Blueprint
 
@@ -313,17 +313,17 @@ RuntimeError: Working outside of application context.
 正如构建此应用时你所看到的，在启动服务器之前，有许多配置选项取决于在环境中设置的变量。 这包括密钥、电子邮件服务器信息、数据库URL和Microsoft Translator API key。 你可能会和我一样觉得，这很不方便，因为每次打开新的终端会话时，都需要重新设置这些变量。
 > 译者注：可以通过将环境变量设置到开机启动中，来保持它们在该计算机中的所有终端中都生效。
 
-应用依赖大量环境变量的常见处理模式是将这些变量存储在应用根目录中的*.env*文件中。 应用在启动时会从此文件中导入变量，这样就不需要你手动设置这些变量了。
+应用依赖大量环境变量的常见处理模式是将这些变量存储在应用根目录中的 *.env* 文件中。 应用在启动时会从此文件中导入变量，这样就不需要你手动设置这些变量了。
 
-有一个支持*.env*文件的Python包，名为`python-dotenv`。 所以让我们安装这个包：
+有一个支持 *.env* 文件的Python包，名为`python-dotenv`。 所以让我们安装这个包：
 
 ```
 (venv) $ pip install python-dotenv
 ```
 
-由于*config.py*模块是我读取所有环境变量的地方，因此我将在创建Config类之前导入*.env*文件，以便在构造类时设置变量：
+由于*config.py*模块是我读取所有环境变量的地方，因此我将在创建Config类之前导入 *.env* 文件，以便在构造类时设置变量：
 
-*config.py*：导入.env文件中的环境变量。
+*config.py*：导入 *.env* 文件中的环境变量。
 
 ```
 import os
@@ -336,11 +336,11 @@ class Config(object):
     # ...
 ```
 
-现在你可以创建一个*.env*文件并在其中写入应用所需的所有环境变量了。不要将*.env*文件加入到源代码版本控制中，这非常重要。否则，一旦你的密码和其他重要信息上传到远程代码库中后，你就会后悔莫及。
+现在你可以创建一个 *.env* 文件并在其中写入应用所需的所有环境变量了。不要将 *.env* 文件加入到源代码版本控制中，这非常重要。否则，一旦你的密码和其他重要信息上传到远程代码库中后，你就会后悔莫及。
 
 *.env*文件可以用于所有配置变量，但是不能用于Flask命令行的`FLASK_APP`和`FLASK_DEBUG`环境变量，因为它们在应用启动的早期（应用实例和配置对象存在之前）就被使用了。
 
-以下示例显示了*.env*文件，该文件定义了一个安全密钥，将电子邮件配置为在本地运行的邮件服务器的25端口上，并且不进行身份验证，设置Microsoft Translator API key，使用数据库配置的默认值：
+以下示例显示了 *.env* 文件，该文件定义了一个安全密钥，将电子邮件配置为在本地运行的邮件服务器的25端口上，并且不进行身份验证，设置Microsoft Translator API key，使用数据库配置的默认值：
 
 ```
 SECRET_KEY=a-really-long-and-unique-key-that-nobody-knows


### PR DESCRIPTION
第一处修改少一个星号结束符，之后斜体不能正确显示的原因猜测是，星号后面直接是斜杠*/或者点*.貌似会造成语法问题，目前解决方法是在星号一侧加上空格